### PR TITLE
[#75] Integration of dummy data for products.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -57,6 +57,10 @@ dependencies {
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.2'
 	implementation 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 
+	// Datafaker
+	implementation'net.datafaker:datafaker:2.4.2'
+
+
 	// Development tools
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/api/src/main/java/com/marketplace/configuration/AppConfig.java
+++ b/api/src/main/java/com/marketplace/configuration/AppConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 @RequiredArgsConstructor
@@ -37,5 +38,10 @@ public class AppConfig {
         authenticationProvider.setPasswordEncoder(passwordEncoder);
 
         return new ProviderManager(authenticationProvider);
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/api/src/main/java/com/marketplace/configuration/ProductDataInitializer.java
+++ b/api/src/main/java/com/marketplace/configuration/ProductDataInitializer.java
@@ -1,0 +1,123 @@
+package com.marketplace.configuration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketplace.entity.Product;
+import com.marketplace.repository.ProductRepository;
+import net.datafaker.Faker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.util.Locale;
+import java.util.stream.IntStream;
+
+
+/**
+ * This class is responsible for fetching product images from Pexels API.
+ * It is used for populating the product images in the database.
+ */
+@Component
+@RequiredArgsConstructor
+@Profile("dev")
+public class ProductDataInitializer implements CommandLineRunner {
+
+    private final ProductRepository productRepository;
+    private final RestTemplate restTemplate;
+
+   @Value("${pexels.api.key}")
+    private String apiKey;
+
+    @Override
+    public void run(String... args) {
+        if (productRepository.count() == 0) {
+
+            Faker faker = new Faker( Locale.ENGLISH);
+
+            IntStream.range(0, 60).forEach(i -> {
+                int stockQuantity = faker.number().numberBetween(1, 500);
+                int maxQuantityByPurchase = faker.number().numberBetween(1, stockQuantity);
+                int stepQuantity = faker.options().option(1, 2, 3, 5, 10);
+
+
+                String productName = faker.commerce().productName();
+                String imageUrl = fetchImageFromPexels(productName);
+
+                Product product = Product.builder()
+                        .name(productName)
+                        .description(faker.lorem().sentence())
+                        .photo(imageUrl)
+                        .unitPrice(BigDecimal.valueOf(faker.number().randomDouble(2, 1, 100)))
+                        .nutritionalValue(String.join(", ", faker.food().spice()))
+                        .listOfIngredients(String.join(", ", faker.food().ingredient()))
+                        .stockQuantity(stockQuantity)
+                        .maxQuantityByPurchase(maxQuantityByPurchase)
+                        .stepQuantity(stepQuantity)
+                        .criticalLevel(faker.number().numberBetween(1, 10))
+                        .active(i % 5 != 0)
+                        .build();
+                productRepository.save(product);
+                System.out.println("Saving product with image URL: " + imageUrl);
+
+            });
+            System.out.println("60 fake products have been added to the database.");
+
+
+        }
+    }
+
+    /**
+     * Fetches an image URL from the Pexels API based on the given query.
+     *
+     * @param query The search query (e.g., product name) to find a relevant image.
+     * @return The URL of the image if found, or a default placeholder URL if any error occurs.
+     */
+    protected String fetchImageFromPexels(String query) {
+        String url = "https://api.pexels.com/v1/search?query=" + query + "&per_page=1";
+
+        try {
+            // Set up headers with the API key
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", apiKey);
+            // Create an HTTP entity with the headers(API request)
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+            String response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class).getBody();
+
+            // Parse the JSON response using Jackson
+            if (response != null) {
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode rootNode = objectMapper.readTree(response);
+
+                // Navigate to the URL of the first image
+                JsonNode photosNode = rootNode.path("photos");
+                if (photosNode.isArray() && photosNode.size() > 0) {
+                    JsonNode photoNode = photosNode.get(0).path("src").path("original");
+                    if (!photoNode.isMissingNode()) {
+                        return photoNode.asText();
+                    }
+                }
+            }
+            // Return a placeholder image if the response is invalid
+            return "https://via.placeholder.com/300";
+        } catch (Exception e) {
+            return "https://via.placeholder.com/300";
+        }
+    }
+}
+
+
+
+
+
+
+
+
+
+

--- a/api/src/main/java/com/marketplace/configuration/ProductDataInitializer.java
+++ b/api/src/main/java/com/marketplace/configuration/ProductDataInitializer.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketplace.entity.Product;
 import com.marketplace.repository.ProductRepository;
 import net.datafaker.Faker;
+import org.slf4j.Logger;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
@@ -16,6 +18,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.web.client.RestTemplate;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.stream.IntStream;
 
@@ -31,24 +35,42 @@ public class ProductDataInitializer implements CommandLineRunner {
 
     private final ProductRepository productRepository;
     private final RestTemplate restTemplate;
+    private static final Logger logger = LoggerFactory.getLogger(ProductDataInitializer.class);
 
-   @Value("${pexels.api.key}")
+   @Value("${unsplash.api.key}")
     private String apiKey;
 
     @Override
     public void run(String... args) {
-        if (productRepository.count() == 0) {
+       if (productRepository.count() == 0) {
+            Faker faker = new Faker( Locale.FRANCE);
 
-            Faker faker = new Faker( Locale.ENGLISH);
+            List<String> localProductNames = Arrays.asList(
+                    "Miel d'acacia", "Fromage de chèvre", "Pomme bio", "Pain complet",
+                    "Confiture de framboises", "Herbes aromatiques fraîches", "Carottes du potager", "Poulet fermier",
+                    "Huile d'olive artisanale", "Sirop d'érable biologique", "Yaourt fermier au lait entier",
+                    "Tisanes aux plantes médicinales"," Graines de sésame ",
+                    "Charcuterie artisanale fumée","Œufs de poules élevées en plein air",
+                    "Beurre fermier au lait cru", "Fraises","Ratatouille aux légumes bio",
+                    "Courgettes","Jus de pommes artisanal", "Huile de noix extra vierge",
+                    "Cassoulet", "Pomme de Terre", "Tomate Bio",
+                    "Laitue batavia"
+            );
+
+           List<String> imageUrls = fetchImagesFromUnsplashCollection("1155327", localProductNames.size());
 
             IntStream.range(0, 60).forEach(i -> {
                 int stockQuantity = faker.number().numberBetween(1, 500);
                 int maxQuantityByPurchase = faker.number().numberBetween(1, stockQuantity);
                 int stepQuantity = faker.options().option(1, 2, 3, 5, 10);
 
+                String imageUrl = imageUrls.get(i % imageUrls.size());
+                String productName = localProductNames.get(faker.random().nextInt(localProductNames.size()));
 
-                String productName = faker.commerce().productName();
-                String imageUrl = fetchImageFromPexels(productName);
+                String listOfIngredients = String.join(", ", IntStream.range(0, 3)
+                        .mapToObj(j -> faker.food().ingredient())
+                        .distinct()
+                        .toList());
 
                 Product product = Product.builder()
                         .name(productName)
@@ -56,7 +78,7 @@ public class ProductDataInitializer implements CommandLineRunner {
                         .photo(imageUrl)
                         .unitPrice(BigDecimal.valueOf(faker.number().randomDouble(2, 1, 100)))
                         .nutritionalValue(String.join(", ", faker.food().spice()))
-                        .listOfIngredients(String.join(", ", faker.food().ingredient()))
+                        .listOfIngredients(listOfIngredients)
                         .stockQuantity(stockQuantity)
                         .maxQuantityByPurchase(maxQuantityByPurchase)
                         .stepQuantity(stepQuantity)
@@ -68,51 +90,53 @@ public class ProductDataInitializer implements CommandLineRunner {
 
             });
             System.out.println("60 fake products have been added to the database.");
-
-
-        }
+       }
     }
 
     /**
-     * Fetches an image URL from the Pexels API based on the given query.
-     *
-     * @param query The search query (e.g., product name) to find a relevant image.
-     * @return The URL of the image if found, or a default placeholder URL if any error occurs.
+     * @param collectionId Collection ID from Unsplash
+     * @param totalImages Number of images to fetch
+     * @return List of image URLs
      */
-    protected String fetchImageFromPexels(String query) {
-        String url = "https://api.pexels.com/v1/search?query=" + query + "&per_page=1";
-
+    protected List<String> fetchImagesFromUnsplashCollection(String collectionId, int totalImages) {
+        String url = "https://api.unsplash.com/collections/" + collectionId + "/photos?per_page=" + totalImages;
         try {
-            // Set up headers with the API key
+            /* Set up headers with the API key */
             HttpHeaders headers = new HttpHeaders();
-            headers.set("Authorization", apiKey);
-            // Create an HTTP entity with the headers(API request)
-            HttpEntity<String> entity = new HttpEntity<>(headers);
-            String response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class).getBody();
+            headers.set("Authorization", "Client-ID " + apiKey);
 
-            // Parse the JSON response using Jackson
+            /* Create an HTTP entity with the headers(API request) */
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+            System.out.println("Querying Unsplash with URL: " + url);
+
+            /* Fetch the response */
+            String response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class).getBody();
+            System.out.println("Response from Unsplash: " + response);
+
+            /* Parse the JSON response using Jackson */
             if (response != null) {
                 ObjectMapper objectMapper = new ObjectMapper();
                 JsonNode rootNode = objectMapper.readTree(response);
 
-                // Navigate to the URL of the first image
-                JsonNode photosNode = rootNode.path("photos");
-                if (photosNode.isArray() && photosNode.size() > 0) {
-                    JsonNode photoNode = photosNode.get(0).path("src").path("original");
-                    if (!photoNode.isMissingNode()) {
-                        return photoNode.asText();
-                    }
-                }
+                List<String> imageUrls = IntStream.range(0, rootNode.size())
+                        .mapToObj(i -> {
+                            String rawUrl = rootNode.get(i).path("urls").path("small").asText("https://via.placeholder.com/300");
+                            return rawUrl + "&w=300&h=300";
+                        })
+                        .toList();
+
+                System.out.println("Fetched " + imageUrls.size() + " images from Unsplash.");
+                return imageUrls;
             }
-            // Return a placeholder image if the response is invalid
-            return "https://via.placeholder.com/300";
         } catch (Exception e) {
-            return "https://via.placeholder.com/300";
+            logger.error("An error occurred while fetching images from Unsplash: {}", e.getMessage(), e);
+            return List.of("https://via.placeholder.com/300");
         }
+
+        /* Return an empty list if the request fails */
+        return List.of();
     }
 }
-
-
 
 
 

--- a/api/src/main/java/com/marketplace/entity/Product.java
+++ b/api/src/main/java/com/marketplace/entity/Product.java
@@ -25,7 +25,10 @@ public class Product{
     private Long id;
     private String name;
     private String description;
+
+    @Column(length = 500)
     private String photo;
+
     private BigDecimal unitPrice;
     private String nutritionalValue;
     private String listOfIngredients;

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -52,3 +52,8 @@ app:
       secret-key: ${JWT_SECRET}
       access-token-expiration: 900000 #15mins
       refresh-token-expiration: 86400000 #1day
+
+pexels:
+  api:
+    key: ${PEXELS_API_KEY}
+

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -53,7 +53,6 @@ app:
       access-token-expiration: 900000 #15mins
       refresh-token-expiration: 86400000 #1day
 
-pexels:
+unsplash:
   api:
-    key: ${PEXELS_API_KEY}
-
+    key: ${UNSPLASH_API_KEY}

--- a/api/src/test/java/com/marketplace/configuration/ProductImageTest.java
+++ b/api/src/test/java/com/marketplace/configuration/ProductImageTest.java
@@ -1,0 +1,95 @@
+package com.marketplace.configuration;
+
+import com.marketplace.entity.Product;
+import com.marketplace.repository.ProductRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Tests for ProductImage")
+@Nested
+public class ProductImageTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Test
+    @DisplayName("Test Product Images with Mocked Data")
+    public void testProductImages_withMockedData() {
+
+        Product product1 = Product.builder().name("Apple").photo("https://valid-image-url.com").build();
+        Product product2 = Product.builder().name("Orange").photo("https://valid-image-url.com").build();
+        List<Product> mockProducts = List.of(product1, product2);
+
+        Mockito.when(productRepository.findAll()).thenReturn(mockProducts);
+
+        List<Product> products = productRepository.findAll();
+        for (Product product : products) {
+            assertNotNull(product.getPhoto(), "Image URL is null for product: " + product.getName());
+            assertFalse(product.getPhoto().equals("https://via.placeholder.com/300"),
+                    "Placeholder image found for product: " + product.getName());
+        }
+    }
+
+    @Test
+    @DisplayName("Test Fetch Image From Pexels with Valid API Key")
+    public void testFetchImageFromPexels_withValidApiKey() {
+        String apiKey = System.getenv("PEXELS_API_KEY");
+        assertNotNull(apiKey, "API Key should be set in the environment variables.");
+
+        ProductDataInitializer initializer = new ProductDataInitializer(null, new RestTemplate());
+        ReflectionTestUtils.setField(initializer, "apiKey", apiKey);
+
+        try {
+
+            String imageUrl = initializer.fetchImageFromPexels("apple");
+
+            assertNotNull(imageUrl, "Image URL should not be null.");
+            assertFalse(imageUrl.equals("https://via.placeholder.com/300"), "Placeholder image returned unexpectedly.");
+
+        } catch (HttpClientErrorException e) {
+            Assertions.fail("API call failed with status: " + e.getStatusCode() + " and message: " + e.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("Test Fetch Image From Pexels with Error Response")
+    public void testFetchImageFromPexels_withErrorResponse() {
+        String apiKey = System.getenv("PEXELS_API_KEY");
+        assertNotNull(apiKey, "API Key should be set in the environment variables.");
+
+        RestTemplate mockRestTemplate = Mockito.mock(RestTemplate.class);
+        ProductDataInitializer initializer = new ProductDataInitializer(null, mockRestTemplate);
+        ReflectionTestUtils.setField(initializer, "apiKey", apiKey);
+
+
+        Mockito.when(mockRestTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.eq(HttpMethod.GET),
+                Mockito.any(HttpEntity.class),
+                Mockito.eq(String.class)
+        )).thenThrow(new RuntimeException("Simulated API error"));
+
+
+        String imageUrl = initializer.fetchImageFromPexels("invalid_query");
+
+        assertNotNull(imageUrl, "Image URL should not be null even in case of error.");
+        assertEquals("https://via.placeholder.com/300", imageUrl, "Error case should return the placeholder URL.");
+    }
+
+}

--- a/api/src/test/java/com/marketplace/configuration/ProductImageTest.java
+++ b/api/src/test/java/com/marketplace/configuration/ProductImageTest.java
@@ -1,6 +1,6 @@
 package com.marketplace.configuration;
 
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -10,7 +10,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
@@ -23,44 +22,39 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ProductImageTest {
 
     @Test
-    @DisplayName("Test Fetch Multiple Images From Unsplash Collection")
-    public void testFetchImagesFromUnsplashCollection() {
-        String apiKey = System.getenv("UNSPLASH_API_KEY");
-        assertNotNull(apiKey, "API Key should be set in the environment variables.");
+    @DisplayName("Test Fetch Images From Unsplash with Mocked API")
+    public void testFetchImagesFromUnsplashWithMock() {
+        // Mock du RestTemplate
+        RestTemplate mockRestTemplate = Mockito.mock(RestTemplate.class);
 
-        ProductDataInitializer initializer = new ProductDataInitializer(null, new RestTemplate());
-        ReflectionTestUtils.setField(initializer, "apiKey", apiKey);
+        // Instance de ProductDataInitializer avec le RestTemplate mocké
+        ProductDataInitializer initializer = new ProductDataInitializer(null, mockRestTemplate);
 
-        List<String> images = initializer.fetchImagesFromUnsplashCollection("1155327", 10);
+        // Mock de la réponse de l'API
+        String mockResponse = """
+        [
+            {"urls": {"small": "https://image-url-1.com"}},
+            {"urls": {"small": "https://image-url-2.com"}}
+        ]
+    """;
+
+        Mockito.when(mockRestTemplate.exchange(
+                Mockito.anyString(),
+                Mockito.eq(HttpMethod.GET),
+                Mockito.any(HttpEntity.class),
+                Mockito.eq(String.class)
+        )).thenReturn(new org.springframework.http.ResponseEntity<>(mockResponse, org.springframework.http.HttpStatus.OK));
+
+        // Appel de la méthode testée
+        List<String> images = initializer.fetchImagesFromUnsplashCollection("1165522", 2);
 
         // Assertions
         assertNotNull(images, "Image list should not be null.");
-        assertFalse(images.isEmpty(), "Image list should contain images.");
-        assertTrue(images.size() <= 10, "Image list size should not exceed the requested number.");
-        assertFalse(images.contains("https://via.placeholder.com/300"), "Image list should not contain placeholder URLs.");
+        assertEquals(2, images.size(), "Image list should contain two images.");
+        assertEquals("https://image-url-1.com&w=300&h=300", images.get(0));
+        assertEquals("https://image-url-2.com&w=300&h=300", images.get(1));
     }
 
-    @Test
-    @DisplayName("Test Fetch Image From Unsplash with Valid API Key")
-    public void testFetchImageFromUnsplash_withValidApiKey() {
-        String apiKey = System.getenv("UNSPLASH_API_KEY");
-        assertNotNull(apiKey, "API Key should be set in the environment variables.");
-
-        ProductDataInitializer initializer = new ProductDataInitializer(null, new RestTemplate());
-        ReflectionTestUtils.setField(initializer, "apiKey", apiKey);
-
-        try {
-
-            List<String> images = initializer.fetchImagesFromUnsplashCollection("1155327", 5);
-
-            assertNotNull(images, "Image list should not be null.");
-            assertFalse(images.isEmpty(), "Image list should not be empty.");
-            assertFalse(images.contains("https://via.placeholder.com/300"), "Image list should not contain placeholder URLs.");
-
-        } catch (HttpClientErrorException e) {
-            Assertions.fail("API call failed with status: " + e.getStatusCode() + " and message: " + e.getMessage());
-        }
-    }
 
     @Test
     @DisplayName("Test Fetch Images From Unsplash Collection with Error")

--- a/api/src/test/java/com/marketplace/configuration/ProductImageTest.java
+++ b/api/src/test/java/com/marketplace/configuration/ProductImageTest.java
@@ -1,13 +1,10 @@
 package com.marketplace.configuration;
 
-import com.marketplace.entity.Product;
-import com.marketplace.repository.ProductRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
@@ -25,31 +22,28 @@ import static org.junit.jupiter.api.Assertions.*;
 @Nested
 public class ProductImageTest {
 
-    @Mock
-    private ProductRepository productRepository;
-
     @Test
-    @DisplayName("Test Product Images with Mocked Data")
-    public void testProductImages_withMockedData() {
+    @DisplayName("Test Fetch Multiple Images From Unsplash Collection")
+    public void testFetchImagesFromUnsplashCollection() {
+        String apiKey = System.getenv("UNSPLASH_API_KEY");
+        assertNotNull(apiKey, "API Key should be set in the environment variables.");
 
-        Product product1 = Product.builder().name("Apple").photo("https://valid-image-url.com").build();
-        Product product2 = Product.builder().name("Orange").photo("https://valid-image-url.com").build();
-        List<Product> mockProducts = List.of(product1, product2);
+        ProductDataInitializer initializer = new ProductDataInitializer(null, new RestTemplate());
+        ReflectionTestUtils.setField(initializer, "apiKey", apiKey);
 
-        Mockito.when(productRepository.findAll()).thenReturn(mockProducts);
+        List<String> images = initializer.fetchImagesFromUnsplashCollection("1155327", 10);
 
-        List<Product> products = productRepository.findAll();
-        for (Product product : products) {
-            assertNotNull(product.getPhoto(), "Image URL is null for product: " + product.getName());
-            assertFalse(product.getPhoto().equals("https://via.placeholder.com/300"),
-                    "Placeholder image found for product: " + product.getName());
-        }
+        // Assertions
+        assertNotNull(images, "Image list should not be null.");
+        assertFalse(images.isEmpty(), "Image list should contain images.");
+        assertTrue(images.size() <= 10, "Image list size should not exceed the requested number.");
+        assertFalse(images.contains("https://via.placeholder.com/300"), "Image list should not contain placeholder URLs.");
     }
 
     @Test
-    @DisplayName("Test Fetch Image From Pexels with Valid API Key")
-    public void testFetchImageFromPexels_withValidApiKey() {
-        String apiKey = System.getenv("PEXELS_API_KEY");
+    @DisplayName("Test Fetch Image From Unsplash with Valid API Key")
+    public void testFetchImageFromUnsplash_withValidApiKey() {
+        String apiKey = System.getenv("UNSPLASH_API_KEY");
         assertNotNull(apiKey, "API Key should be set in the environment variables.");
 
         ProductDataInitializer initializer = new ProductDataInitializer(null, new RestTemplate());
@@ -57,10 +51,11 @@ public class ProductImageTest {
 
         try {
 
-            String imageUrl = initializer.fetchImageFromPexels("apple");
+            List<String> images = initializer.fetchImagesFromUnsplashCollection("1155327", 5);
 
-            assertNotNull(imageUrl, "Image URL should not be null.");
-            assertFalse(imageUrl.equals("https://via.placeholder.com/300"), "Placeholder image returned unexpectedly.");
+            assertNotNull(images, "Image list should not be null.");
+            assertFalse(images.isEmpty(), "Image list should not be empty.");
+            assertFalse(images.contains("https://via.placeholder.com/300"), "Image list should not contain placeholder URLs.");
 
         } catch (HttpClientErrorException e) {
             Assertions.fail("API call failed with status: " + e.getStatusCode() + " and message: " + e.getMessage());
@@ -68,15 +63,11 @@ public class ProductImageTest {
     }
 
     @Test
-    @DisplayName("Test Fetch Image From Pexels with Error Response")
-    public void testFetchImageFromPexels_withErrorResponse() {
-        String apiKey = System.getenv("PEXELS_API_KEY");
-        assertNotNull(apiKey, "API Key should be set in the environment variables.");
-
+    @DisplayName("Test Fetch Images From Unsplash Collection with Error")
+    public void testFetchImagesFromUnsplashCollection_withError() {
         RestTemplate mockRestTemplate = Mockito.mock(RestTemplate.class);
         ProductDataInitializer initializer = new ProductDataInitializer(null, mockRestTemplate);
-        ReflectionTestUtils.setField(initializer, "apiKey", apiKey);
-
+        ReflectionTestUtils.setField(initializer, "apiKey", "invalid_api_key");
 
         Mockito.when(mockRestTemplate.exchange(
                 Mockito.anyString(),
@@ -85,11 +76,11 @@ public class ProductImageTest {
                 Mockito.eq(String.class)
         )).thenThrow(new RuntimeException("Simulated API error"));
 
+        List<String> images = initializer.fetchImagesFromUnsplashCollection("1155327", 10);
 
-        String imageUrl = initializer.fetchImageFromPexels("invalid_query");
-
-        assertNotNull(imageUrl, "Image URL should not be null even in case of error.");
-        assertEquals("https://via.placeholder.com/300", imageUrl, "Error case should return the placeholder URL.");
+       //Assertions
+        assertNotNull(images, "Image list should not be null even in case of error.");
+        assertEquals(List.of("https://via.placeholder.com/300"), images,
+                "Image list should contain a placeholder in case of error.");
     }
-
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,7 @@
 services:
   backend:
+    env_file:
+      - .env
     environment:
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
@@ -9,6 +11,7 @@ services:
       GOOGLE_SECRET_CLIENT: ${GOOGLE_SECRET_CLIENT}
       FACEBOOK_CLIENT_ID: ${FACEBOOK_CLIENT_ID}
       FACEBOOK_SECRET_CLIENT: ${FACEBOOK_SECRET_CLIENT}
+      PEXELS_API_KEY: ${PEXELS_API_KEY}
       DB_HOST: db
       DB_PORT: 5432
     build:

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,7 +11,7 @@ services:
       GOOGLE_SECRET_CLIENT: ${GOOGLE_SECRET_CLIENT}
       FACEBOOK_CLIENT_ID: ${FACEBOOK_CLIENT_ID}
       FACEBOOK_SECRET_CLIENT: ${FACEBOOK_SECRET_CLIENT}
-      PEXELS_API_KEY: ${PEXELS_API_KEY}
+      UNSPLASH_API_KEY: ${UNSPLASH_API_KEY}
       DB_HOST: db
       DB_PORT: 5432
     build:
@@ -67,6 +67,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       DB_HOST: db
       DB_PORT: 5432
+      UNSPLASH_API_KEY: ${UNSPLASH_API_KEY}
     depends_on:
       - db
     networks:


### PR DESCRIPTION

## Description
Cette Pull Request implémente un système de génération de données factices pour l'entité `Product`. Ces données permettent de faciliter les tests fonctionnels et l'intégration des fonctionnalités liées aux produits dans l'application marketplace.

### Modifications incluses :
- Ajout d'un **Seeder** pour générer automatiquement des produits factices avec des valeurs réalistes et variées.
- Utilisation de la bibliothèque [Datafaker](https://www.datafaker.net/) pour générer les données.
- Configuration d'un `CommandLineRunner` exécuté uniquement dans le profil `dev`.
- Génération de **60 produits factices** dans une table "products" vide

## Pré-requis pour tester la fonctionnalité

### 1. Configuration de l'API Unsplash
Pour générer des images factices via l'API Unsplash :
- Créez un compte Unsplash [ici](https://unsplash.com/join). Puis dans le menu API/Développeur
- Renseignez les informations de l'application dans le tableau de bord Unsplash pour générer une clé d'accès API.
- Ajoutez la clé d'accès dans le fichier `.env` :
  ```UNSPLASH_API_KEY=your_unsplash_access_key ```

### 2. Configuration de l'accès aux endpoints dans SecurityConfig
Pour tester les endpoints liés aux produits dans le navigateur :
- Ajoutez l'URL /products/** à la liste blanche API_URLS_WHITELIST dans la classe SecurityConfig.

## Etape suivante 
- Implémentation côté Front de la relation avec l'API 

## Issue liée
Closes #75